### PR TITLE
Toevoegen ontbrekende rwd vertaalstring "Apply"

### DIFF
--- a/app/locale/nl_NL/Mage_Checkout.csv
+++ b/app/locale/nl_NL/Mage_Checkout.csv
@@ -19,6 +19,7 @@
 "An error occurred in the process of payment","Er is een fout opgetreden tijdens het betalen"
 "An error occurred while deleting this condition.","Er is een fout opgetreden bij het verwijderen van deze conditie"
 "An error occurred while saving this condition.","Er is een fout opgetreden bij het opslaan van deze conditie"
+"Apply","Toepassen"
 "Apply Coupon","Kortingscode gebruiken"
 "Are you sure you want to leave this page? You will need to go through the checkout steps again.","Weet u zeker dat u deze pagina wilt verlaten? U dient de stappen om af te rekenen opnieuw te doorlopen."
 "Are you sure you would like to remove this item from the shopping cart?","Weet u zeker dat u dit artikel wilt verwijderen uit uw winkelwagen?"


### PR DESCRIPTION
In base/default/template/checkout/cart/coupon.phtml wordt de string "Apply Coupon" gebruikt, maar in rwd/default/template/checkout/cart/coupon.phtml is deze gewijzigd in "Apply". Dit is daarna niet terecht gekomen in de en_US translations, maar is wel nodig in de nl_NL translations om de vertaling te kunnen doen.
