### PR TITLE
Add branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "ho-nl/ho_nl_nl",
     "type": "magento-module",
     "license":"OSL-3.0",
-    "description":"Nederlandse vertalingen voor Magento 1.7.0.2",
+    "description":"Nederlandse vertalingen voor Magento",
     "homepage": "http://www.h-o.nl/blog/nederlandse-vertalingen-magento-17-inclusief-e-mailvertalingen/",
     "authors":[
         {
@@ -12,5 +12,10 @@
     ],
     "require": {
         "magento-hackathon/magento-composer-installer": "*"
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.9-dev"
+        }
     }
 }


### PR DESCRIPTION
Met een branch-alias kan je in composer een bepaalde versie vastzetten (`composer require ho-nl/ho_nl_nl "1.9.x@dev"`).
Dan kunnen we nu de laatste versie gebruiken, ipv de laatste release alleen.
(Releases zou je eigenlijk 1.9.0 moeten noemen, niet 1.9.x)