### PR TITLE
Ontbrekende vertaling van "View Details" toegevoegd

### DIFF
--- a/app/locale/nl_NL/Mage_Catalog.csv
+++ b/app/locale/nl_NL/Mage_Catalog.csv
@@ -772,6 +772,7 @@
 "Value for ""%s"" is invalid.","Waarde voor ""%s"" is ongeldig."
 "Value for ""%s"" is invalid: %s","Waarde voor ""%s"" is ongeldig: %s"
 "Varchar","Varchar"
+"View Details","Bekijk details"
 "View as","Tonen als"
 "Virtual Product","Virtueel product"
 "Visibility","Zichtbaarheid"


### PR DESCRIPTION
String bestaat wel in de en_US versie van Mage_Catalog.csv en wordt gebruikt in app/design/frontend/rwd/default/template/catalog/product/list.phtml