### PR TITLE
Bestelling met betaalverplichting

### DIFF
--- a/app/locale/nl_NL/Mage_Checkout.csv
+++ b/app/locale/nl_NL/Mage_Checkout.csv
@@ -206,7 +206,7 @@
 "Payment method is not defined","Betaalmethode is niet gedefinieerd"
 "Payment methods in shopping cart","Betaalmethoden in winkelwagen"
 "Payment profile # %s: ""%s"".","Abonnement %s: ""%s""."
-"Place Order","Plaats bestelling"
+"Place Order","Afrekenen"
 "Please agree to all Terms and Conditions before placing the order.","Accepteer onze Algemene Voorwaarden voordat u de bestelling plaatst a.u.b."
 "Please agree to all Terms and Conditions before placing the orders.","Accepteer onze Algemene Voorwaarden voordat u de bestelling plaatst a.u.b."
 "Please agree to all the terms and conditions before placing the order.","Accepteer onze Algemene Voorwaarden voordat u de bestelling plaatst a.u.b."


### PR DESCRIPTION
Volgens de Europese wet moet de klant weten dat hij een bestelling met betaalverplichting aan gaat.
Op de bestelknop (laatste knop voor men definitief bestelt). Duidelijk moet worden dat de consument door het klikken op de knop een bestelling plaatst en een betaalverplichting aangaat. Dit kan bijvoorbeeld met tekst "bestellen met betaalplicht", "afrekenen" of "kopen".