### PR TITLE
hotfix for missing Fooman_PdfCustomiser.csv file

### DIFF
--- a/modman
+++ b/modman
@@ -48,7 +48,6 @@ app/locale/nl_NL/F500_Afterpay.csv app/locale/nl_NL/F500_Afterpay.csv
 app/locale/nl_NL/F500_Xibpayments.csv app/locale/nl_NL/F500_Xibpayments.csv
 app/locale/nl_NL/Find_Feed.csv app/locale/nl_NL/Find_Feed.csv
 app/locale/nl_NL/Flagbit_Faq.csv app/locale/nl_NL/Flagbit_Faq.csv
-app/locale/nl_NL/Fooman_PdfCustomiser.csv app/locale/nl_NL/Fooman_PdfCustomiser.csv
 app/locale/nl_NL/Ho_AbcMail.csv app/locale/nl_NL/Ho_AbcMail.csv
 app/locale/nl_NL/Ho_Adminimprovements.csv app/locale/nl_NL/Ho_Adminimprovements.csv
 app/locale/nl_NL/Ho_Browsercompat.csv app/locale/nl_NL/Ho_Browsercompat.csv


### PR DESCRIPTION
file was removed, but meta data file was not updated.